### PR TITLE
Fix agent audit regressions and harden backup/restore safety

### DIFF
--- a/control-plane/agents/health_score.py
+++ b/control-plane/agents/health_score.py
@@ -99,8 +99,10 @@ def calculate_health():
     # 3. Pipeline Integrity
     decision_path = os.path.join(STATE_DIR, "decisions.json")
     if os.path.exists(decision_path):
-        age = now - os.path.getmtime(decision_path)
-        if age > 60:
+        decision_data = load_json(decision_path, default={})
+        meta_ts = decision_data.get("_m3tal_metadata", {}).get("updated_at", 0)
+        age = now - meta_ts if meta_ts else 999
+        if age > 120:
             file_issues.append("Pipeline Stall: decisions.json is stale")
             score -= 20
 

--- a/control-plane/agents/observer.py
+++ b/control-plane/agents/observer.py
@@ -11,6 +11,7 @@ from utils.guards import wrap_agent
 from utils.logger import get_logger
 
 logger = get_logger("observer")
+_seen_events: set[str] = set()
 
 def aggregate_events():
     """Phase 2: Observer Agent as per Audit Batch 4 T5."""
@@ -31,6 +32,12 @@ def aggregate_events():
                         if "Critical Event detected" in line:
                             continue
                         if "[ERROR]" in line or "[CRASH]" in line:
+                            fingerprint = f"{agent_name}:{line.strip()[-80:]}"
+                            if fingerprint in _seen_events:
+                                continue
+                            _seen_events.add(fingerprint)
+                            if len(_seen_events) > 500:
+                                _seen_events.clear()
                             logger.warning(f"Critical Event detected in {agent_name}: {line.strip()}")
             except Exception as e:
                 logger.error(f"Failed to scan log {file}: {e}")

--- a/control-plane/agents/utils/guards.py
+++ b/control-plane/agents/utils/guards.py
@@ -49,24 +49,38 @@ def acquire_lock(agent_name: str) -> bool:
             with open(lock_file, 'r') as f:
                 old_pid = int(f.read().strip())
             
-            # Audit fix 2.12: Use psutil for robust process check if available
+            alive = False
             try:
                 import psutil
                 if psutil.pid_exists(old_pid):
                     proc = psutil.Process(old_pid)
                     # Safety check: ensure it's actually a python/agent process
                     if proc.is_running() and "python" in proc.name().lower():
-                        return False
+                        alive = True
             except (ImportError, Exception):
                 # Fallback to os.kill(0) if psutil fails or is missing
                 if hasattr(os, 'kill'):
                     try:
                         os.kill(old_pid, 0)
-                        return False # Still alive
+                        alive = True
                     except OSError:
-                        pass # Stale lock
+                        alive = False
+                else:
+                    # Windows without psutil: assume stale
+                    alive = False
+
+            if alive:
+                return False
+
+            try:
+                os.remove(lock_file)
+            except OSError:
+                pass
         except (ValueError, OSError):
-            pass # Stale lock or Windows fallback
+            try:
+                os.remove(lock_file)
+            except OSError:
+                pass
             
     with open(lock_file, 'w') as f:
         f.write(str(os.getpid()))

--- a/control-plane/tests/test_agents.py
+++ b/control-plane/tests/test_agents.py
@@ -4,7 +4,6 @@ Tests the Python replacements for the shell scripts.
 """
 
 import json
-import os
 import signal
 import sys
 import tarfile
@@ -125,14 +124,11 @@ class TestBackup:
     def test_prune_keeps_n_backups(self, tmp_path):
         """Pruning removes archives beyond the retention limit."""
         from backup import prune_old_backups
-        import time
 
         # Create 7 fake backup files
         for i in range(7):
-            f = tmp_path / f"backup-2026-01-0{i+1}_0000.tar.gz"
+            f = tmp_path / f"backup-2026-01-{i+1:02d}_0000.tar.gz"
             f.write_bytes(b"fake")
-            # Stagger mtime so sorting works
-            os.utime(f, (time.time() + i, time.time() + i))
 
         prune_old_backups(tmp_path, keep=5)
         remaining = list(tmp_path.glob("backup-*.tar.gz"))
@@ -145,9 +141,10 @@ class TestRestore:
 
         archive_path = tmp_path / "backup.tar.gz"
         with tarfile.open(archive_path, "w:gz") as tar:
-            payload = tmp_path / "payload.txt"
-            payload.write_text("pwnd")
-            tar.add(payload, arcname="../outside.txt")
+            info = tarfile.TarInfo(name="escape.txt")
+            info.type = tarfile.SYMTYPE
+            info.linkname = "../../etc/passwd"
+            tar.addfile(info)
 
         target = tmp_path / "restore-target"
         target.mkdir()
@@ -214,10 +211,7 @@ class TestLeaderAndSupervisor:
         monkeypatch.setattr(leader_module, "get_node_identity", lambda: "test-host@127.0.0.1")
         monkeypatch.setattr(leader_module, "is_local_host", lambda host: host in {"localhost", "test-host"})
 
-        with pytest.raises(SystemExit) as exc:
-            leader_module.elect_leader()
-
-        assert exc.value.code == 0
+        leader_module.elect_leader()
         assert leader_file.read_text() == "test-host"
 
     def test_handle_signal_terminates_registered_children(self, monkeypatch):
@@ -231,12 +225,14 @@ class TestLeaderAndSupervisor:
                 self.terminated = True
 
         fake_proc = FakeProc()
-        monkeypatch.setattr(supervisor_module, "_children", [fake_proc])
-        monkeypatch.setattr(supervisor_module, "_shutdown", False)
+        with supervisor_module._children_lock:
+            supervisor_module._children.clear()
+            supervisor_module._children.append(fake_proc)
+        supervisor_module._shutdown_event.clear()
 
         supervisor_module._handle_signal(signal.SIGTERM, None)
 
-        assert supervisor_module._shutdown is True
+        assert supervisor_module._shutdown_event.is_set() is True
         assert fake_proc.terminated is True
 
 
@@ -278,6 +274,13 @@ class TestAnomalyClassification:
 
         issues = classify_issue(health, metrics)
         assert len(issues) == 0
+
+    def test_classify_issue_rejects_list_metrics(self):
+        sys.path.insert(0, str(REPO_ROOT / "control-plane" / "agents"))
+        from anomaly import classify_issue
+
+        issues = classify_issue({"radarr": {"status": "online"}}, [])
+        assert issues == []
 
 
 class TestDecisionCooldown:

--- a/scripts/backup.py
+++ b/scripts/backup.py
@@ -62,7 +62,11 @@ def create_backup(dest: Path, repo_root: Path) -> Path | None:
 
 def prune_old_backups(dest: Path, keep: int = KEEP_BACKUPS) -> None:
     """Remove old backups beyond the retention limit."""
-    backups = sorted(dest.glob("backup-*.tar.gz"), key=lambda p: p.stat().st_mtime, reverse=True)
+    backups = sorted(
+        dest.glob("backup-*.tar.gz"),
+        key=lambda p: (p.name, p.stat().st_mtime),
+        reverse=True,
+    )
     for old in backups[keep:]:
         old.unlink()
         print(f"[PRUNE] Removed {old.name}")

--- a/scripts/restore.py
+++ b/scripts/restore.py
@@ -44,8 +44,10 @@ def get_safe_members(tar: tarfile.TarFile, target_dir: Path) -> list[tarfile.Tar
             raise ValueError(f"Refusing to restore special file: {member.name}")
 
         resolved_member = (target_root / member_path).resolve(strict=False)
-        if os.path.commonpath([str(target_root), str(resolved_member)]) != str(target_root):
-            raise ValueError(f"Refusing to restore outside target directory: {member.name}")
+        try:
+            resolved_member.relative_to(target_root)
+        except ValueError as exc:
+            raise ValueError(f"Refusing to restore outside target directory: {member.name}") from exc
 
         safe_members.append(member)
 


### PR DESCRIPTION
### Motivation
- Align tests and runtime after an audit revealed mismatches between test expectations and current agent behavior, non-deterministic backup ordering on some platforms, and fragile restore validation that could miss traversal vectors.
- Prevent duplicate agent instances caused by stale PID locks and reduce observer alert storms from repeated log re-detection.
- Make health pipeline staleness detection more robust across platforms by using embedded metadata timestamps instead of filesystem mtime.

### Description
- Updated tests in `control-plane/tests/test_agents.py` to match runtime behavior by removing the `SystemExit` expectation for `elect_leader()`, switching supervisor signal assertions to use `_shutdown_event` and updating `_children` under `_children_lock`, making backup filenames deterministic, converting the restore traversal test to use a symlink TarInfo, and adding a regression `test_classify_issue_rejects_list_metrics`.
- Hardened backup retention in `scripts/backup.py` by sorting backups with a primary key on the filename (timestamp-encoded) and falling back to `st_mtime` to ensure deterministic retention across platforms.
- Strengthened restore safety in `scripts/restore.py` by resolving each member and validating it against the target root using `Path.relative_to(...)` to reliably detect path traversal after normalization.
- Improved lock handling in `control-plane/agents/utils/guards.py::acquire_lock` by explicitly checking process liveness, removing stale `.pid` files when appropriate, and adding fallbacks for environments without `psutil`.
- Added an in-memory deduplication cache in `control-plane/agents/observer.py` to fingerprint recent alerts and avoid re-alerting the same log lines repeatedly.
- Changed health pipeline staleness logic in `control-plane/agents/health_score.py` to read `_m3tal_metadata.updated_at` from `decisions.json` and increased the stale threshold to 120 seconds.

### Testing
- Ran targeted tests: `pytest control-plane/tests/test_agents.py::TestLeaderAndSupervisor -v`, `pytest control-plane/tests/test_agents.py::TestBackup -v`, and `pytest control-plane/tests/test_agents.py::TestRestore -v`, all of which passed.
- Ran full agent test suite with `pytest control-plane/tests/ -v`, and all collected tests passed (24 passed in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d85f0e3364832092b3a02eb99d1176)