### PR TITLE
Add GitHub Action to build and publish Docker images to ghcr.io

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,117 @@
+name: Docker Publish
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Convert repo name to lowercase
+        id: repo_name
+        run: |
+          REPO_LOWERCASE=$(echo "${{ github.repository }}" | tr '[:upper:]' '[:lower:]')
+          echo "repo=$REPO_LOWERCASE" >> $GITHUB_OUTPUT
+
+      - name: Calculate Version
+        id: version
+        run: |
+          # Read base version from VERSION file
+          if [ -f VERSION ]; then
+            FILE_VERSION=$(cat VERSION | tr -d ' \n\r')
+          else
+            FILE_VERSION="v1.3.0"
+          fi
+
+          # Force a bump to at least 1.4.0 if the file version is older or the same as 1.3.x.
+          # Parse major and minor versions (assuming vMAJOR.MINOR.PATCH format)
+          if [[ $FILE_VERSION =~ ^v([0-9]+)\.([0-9]+)\.([0-9]+)(\.[0-9]+)?$ ]]; then
+            MAJOR="${BASH_REMATCH[1]}"
+            MINOR="${BASH_REMATCH[2]}"
+            PATCH="${BASH_REMATCH[3]}"
+
+            if [ "$MAJOR" -lt 1 ] || { [ "$MAJOR" -eq 1 ] && [ "$MINOR" -lt 4 ]; }; then
+              # Default to v1.4.0 if current is older
+              BASE_VERSION="v1.4.0"
+            else
+              # Use what's in the file (just the major.minor.patch part)
+              BASE_VERSION="v${MAJOR}.${MINOR}.${PATCH}"
+            fi
+          else
+            BASE_VERSION="v1.4.0"
+          fi
+
+          FULL_VERSION="${BASE_VERSION}.${{ github.run_number }}"
+          echo "Computed version: ${FULL_VERSION}"
+
+          echo "VERSION=${FULL_VERSION}" >> $GITHUB_OUTPUT
+
+          # Update the VERSION file to reflect the new version format
+          echo "${FULL_VERSION}" > VERSION
+
+      - name: Extract metadata (tags, labels) for Control Plane Backend
+        id: meta-backend
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.repo }}-backend
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+
+      - name: Build and push Control Plane Backend
+        uses: docker/build-push-action@v5
+        with:
+          context: ./control-plane/go-backend
+          file: ./control-plane/go-backend/Dockerfile
+          push: true
+          tags: ${{ steps.meta-backend.outputs.tags }}
+          labels: ${{ steps.meta-backend.outputs.labels }}
+
+      - name: Extract metadata (tags, labels) for Dashboard
+        id: meta-dashboard
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.repo_name.outputs.repo }}-dashboard
+          tags: |
+            type=raw,value=latest
+            type=raw,value=${{ steps.version.outputs.VERSION }}
+
+      - name: Build and push Dashboard
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./control-plane/Dockerfile.dashboard
+          push: true
+          tags: ${{ steps.meta-dashboard.outputs.tags }}
+          labels: ${{ steps.meta-dashboard.outputs.labels }}
+
+      - name: Commit and Push Version Bump
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          git add VERSION
+          # Only commit if there are changes
+          git diff-index --quiet HEAD || git commit -m "chore: bump version to ${{ steps.version.outputs.VERSION }} [skip ci]"
+          git push


### PR DESCRIPTION
This change introduces an automated workflow that correctly parses and bumps the repository version, builds the backend and dashboard Docker images, and publishes them securely to the GitHub Container Registry.

---
*PR created automatically by Jules for task [16297246269191637753](https://jules.google.com/task/16297246269191637753) started by @jakej985-rgb*